### PR TITLE
Updata pfsFiberTrace with new pixel centers

### DIFF
--- a/tests/data/PFS/CALIB/FIBERTRACE/r/fiberTrace/pfsFiberTrace-2016-11-11-0-1r.fits
+++ b/tests/data/PFS/CALIB/FIBERTRACE/r/fiberTrace/pfsFiberTrace-2016-11-11-0-1r.fits
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:34086a393fe0225060afd4250b9086764a20b9c9f155270f6799edec1aeffda1
-size 1667520
+oid sha256:2329a2194ec4ab2615eb44bea1bea16299ae36bf8fc33eb0dca9378e187eb358
+size 2033280

--- a/tests/data/PFS/postISRCCD/2016-11-11/v0000103/PFFAr1.fits
+++ b/tests/data/PFS/postISRCCD/2016-11-11/v0000103/PFFAr1.fits
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d879f2cd7af028a356237496907601454726529423a16bd2f28110d45e4a33bc
+oid sha256:fbadfd304db7bb6d48ac137b885f7e9176001ee978ce1eae1426fb33fd7a12a0
 size 171077760

--- a/tests/data/PFS/postISRCCD/2016-11-11/v0000104/PFFAr1.fits
+++ b/tests/data/PFS/postISRCCD/2016-11-11/v0000104/PFFAr1.fits
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3ddeb397bf1e31d274f6790db7a16c057b1850c9f83c10a91f9f72769d346c7
-size 171089280
+oid sha256:010cde6865bae3c4c8c2de26a3ec677e47285b506e985f2f54f7eb592dc7cad3
+size 171077760


### PR DESCRIPTION
The postISRCCD images of the flat (visit 104) and the arc
(visit 103) appear outdated as well, so we update these, too.