### PR TITLE
Renamed test pfiDesign files to pfsDesign files.

### DIFF
--- a/raw/pfsDesign-0x0000000000000001.fits
+++ b/raw/pfsDesign-0x0000000000000001.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6e5e9402e7fa0fc3981d4118ce864cadc616701092be8122899bcd8502ccc9b
+size 14400

--- a/raw/pfsDesign-0x0000000000000002.fits
+++ b/raw/pfsDesign-0x0000000000000002.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf6d087d46f26f472218e1d8ed64353f362a9ae67df6082dd8ed670676fd82b7
+size 14400


### PR DESCRIPTION
This is to ensure that test data are in line with the most recent
naming convention in datamodel.txt (for 2D DRP version 5.0.3).

Otherwise, these files would not be accessible in pipeline versions
5.0.3 onwards.